### PR TITLE
PHP8 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {

--- a/src/AbstractFlag.php
+++ b/src/AbstractFlag.php
@@ -1,29 +1,44 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Aeviiq\Enum;
 
 use Aeviiq\Enum\Exception\InvalidArgumentException;
-use MyCLabs\Enum\Enum;
 
-abstract class AbstractFlag extends Enum
+abstract class AbstractFlag
 {
     /**
-     * @var int[]
+     * @var int
+     */
+    protected $value;
+
+    /**
+     * @var array
+     * @psalm-var array<class-string, array<string, mixed>>
+     */
+    protected static $cache = [];
+
+    /**
+     * @var array<int>
      */
     protected static $flags = [];
 
-    public function __construct($value)
+    /**
+     * @throws \ReflectionException
+     */
+    public function __construct(int $value)
     {
         static::$flags[static::class] = \array_sum(static::toArray());
-        parent::__construct($value);
+
+        if (!static::isValid($value)) {
+            throw new \UnexpectedValueException(sprintf('Value \'%s\' is not part of the enum %s', $value, static::class));
+        }
+
+        $this->value = $value;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public static function isValid($value): bool
+    public function getValue(): int
     {
-        return \is_int($value) ? ($value & static::$flags[static::class]) === $value : false;
+        return $this->value;
     }
 
     public function contains(AbstractFlag $flag): bool
@@ -32,11 +47,66 @@ abstract class AbstractFlag extends Enum
             throw new InvalidArgumentException(\sprintf('Argument 1 passed to %s() must be an instance of %s, %s given.', __METHOD__, static::class, \get_class($flag)));
         }
 
-        return $this->isFlagSet($this->getValue(), $flag->getValue());
+        $flagValue = $flag->getValue();
+
+        return ($this->getValue() & $flagValue) === $flagValue;
     }
 
-    protected function isFlagSet(int $flags, int $flag): bool
+    /**
+     * @return array<int>
+     */
+    public function explode(): array
     {
-        return ($flag & $flags) === $flag;
+        $values = [];
+
+        foreach (static::values() as $flag) {
+            if ($this->contains($flag)) {
+                $values[] = $flag->getValue();
+            }
+        }
+
+        return $values;
+    }
+
+    public function count(): int
+    {
+        return count($this->explode());
+    }
+
+    final public function equals(AbstractFlag $variable): bool
+    {
+        return $this->getValue() === $variable->getValue() && static::class === \get_class($variable);
+    }
+
+    /**
+     * @return array<string, static>
+     */
+    public static function values(): array
+    {
+        return array_map(static function ($value) {
+            return new static($value);
+        }, static::toArray());
+    }
+
+    /**
+     * @return array<string, int>
+     *
+     * @throws \ReflectionException
+     */
+    public static function toArray(): array
+    {
+        $class = static::class;
+
+        if (!isset(static::$cache[$class])) {
+            $reflection = new \ReflectionClass($class);
+            static::$cache[$class] = $reflection->getConstants();
+        }
+
+        return static::$cache[$class];
+    }
+
+    public static function isValid(int $value): bool
+    {
+        return ($value & static::$flags[static::class]) === $value;
     }
 }

--- a/src/AbstractFlag.php
+++ b/src/AbstractFlag.php
@@ -13,7 +13,7 @@ abstract class AbstractFlag
 
     /**
      * @var array
-     * @psalm-var array<class-string, array<string, mixed>>
+     * @psalm-var array<class-string, array<string, int>>
      */
     protected static $cache = [];
 
@@ -83,7 +83,7 @@ abstract class AbstractFlag
      */
     public static function values(): array
     {
-        return array_map(static function ($value) {
+        return \array_map(static function ($value) {
             return new static($value);
         }, static::toArray());
     }

--- a/tests/AbstractFlagTest.php
+++ b/tests/AbstractFlagTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Aeviiq\Enum\Tests;
 
@@ -78,6 +78,42 @@ final class AbstractFlagTest extends TestCase
         static::assertTrue($subject->contains($this->createSubject(2)));
         static::assertTrue($subject->contains($this->createSubject(8)));
         static::assertFalse($subject->contains($this->createSubject(11)));
+    }
+
+    /**
+     * @dataProvider explodeDataProvider
+     */
+    public function testExplode($value, array $expected): void
+    {
+        $subject = $this->createSubject($value);
+        self::assertEquals($subject->explode(), $expected);
+    }
+
+    public function explodeDataProvider(): array
+    {
+        return [
+            'Test with defined value' => [2, [2]],
+            'Test with combined value' => [9, [1, 8]],
+            'Test with multiple combined values' => [11, [1, 2, 8]],
+        ];
+    }
+
+    /**
+     * @dataProvider countDataProvider
+     */
+    public function testCount(int $value, int $expectedCount): void
+    {
+        $subject = $this->createSubject($value);
+        self::assertEquals($subject->count(), $expectedCount);
+    }
+
+    public function countDataProvider(): array
+    {
+        return [
+            'Test with 1 value' => [2, 1],
+            'Test with 2 values' => [9, 2],
+            'Test with 3 values' => [11, 3],
+        ];
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Fixes #3 

Due to some changes the `myclabs/php-enum` package made to the internal behaviour of the Enum object, the AbstractFlag could no longer function while extending it. So it had to be pulled apart, and be made it's own class.

Any logical and needed functionality for it has been taken from the Enum.